### PR TITLE
Update elasticutils.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -60,7 +60,7 @@
 	url = git://github.com/jbalogh/django-multidb-router.git
 [submodule "src/elasticutils"]
 	path = src/elasticutils
-	url = git://github.com/mozilla/elasticutils.git
+	url = git://github.com/glogiotatidis/elasticutils.git
 [submodule "src/pyes"]
 	path = src/pyes
 	url = git://github.com/aparo/pyes.git


### PR DESCRIPTION
 We use a forked reposity with patch 0.5 of
elastictutils. When 0.6 of elasticutils gets released and our patch is
included, we should move back to git://github.com/mozilla/elasticutils
